### PR TITLE
8 make function upload and download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-translator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
This pull request includes several enhancements to the `mini-translator` project, focusing on adding file upload and download capabilities to the `BlockTranslator` component. The most important changes are listed below:

### New Features:

* Added file upload functionality to the `BlockTranslator` component, allowing users to upload `.txt`, `.pdf`, `.doc`, and `.docx` files for translation. [[1]](diffhunk://#diff-c1ff391465c886cc2a477bb8ede77bcb37db1c26e59bd2d4e01997c4a88eafb9R58-R95) [[2]](diffhunk://#diff-c1ff391465c886cc2a477bb8ede77bcb37db1c26e59bd2d4e01997c4a88eafb9R147-R172)
* Added a download button to the `BlockTranslator` component, enabling users to download the translated text as a `.txt` file.

### Dependency Updates:

* Updated the `lucide-react` import in `block-translator.tsx` to include `Download` and `Upload` icons.

### Version Update:

* Incremented the version number in `package.json` from `0.1.2` to `0.1.3`.