### PR TITLE
15 make middleware for check first to see website

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-translator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,59 @@
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+
+const PROTECTED_PATHS = ["/profile", "/favorite"]
+
+const isProtectedPath = (path: string): boolean => {
+  return PROTECTED_PATHS.some((protectedPath) => path.startsWith(protectedPath))
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const hasVisited = request.cookies.get("hasVisited")
+  const authToken = request.cookies.get("authToken")
+
+  if (isProtectedPath(pathname)) {
+    if (!authToken) {
+      const signInURL = new URL("/sign-in", request.url)
+      signInURL.searchParams.set("callbackUrl", pathname)
+      return NextResponse.redirect(signInURL)
+    }
+  }
+
+  if (
+    hasVisited &&
+    !pathname.startsWith("/translator") &&
+    !isProtectedPath(pathname)
+  ) {
+    return NextResponse.redirect(new URL("/translator", request.url))
+  }
+
+  const response = NextResponse.next()
+
+  if (!hasVisited) {
+    response.cookies.set("hasVisited", "true", {
+      maxAge: 30 * 24 * 60 * 60,
+      path: "/",
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax"
+    })
+  }
+
+  return response
+}
+
+// Configure middleware matching paths
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except:
+     * 1. /api (API routes)
+     * 2. /_next (Next.js internals)
+     * 3. /_static (static files)
+     * 4. /_vercel (Vercel internals)
+     * 5. /favicon.ico, sitemap.xml (static files)
+     * 6. /login (login page)
+     */
+    "/((?!api|_next|_static|_vercel|favicon.ico|sitemap.xml|login).*)"
+  ]
+}


### PR DESCRIPTION
This pull request includes version updates and the addition of middleware for handling protected paths and user redirection.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.1.3` to `0.1.4`.

### Middleware Addition:
* [`src/middleware.ts`](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R1-R59): Added middleware to handle protected paths, check authentication tokens, and redirect users based on their visit status. This includes setting a cookie to track if a user has visited the site before.